### PR TITLE
Bug Fix - Broadcast players joining lobby

### DIFF
--- a/supa-fighta/src/utils/lobbyUtils.js
+++ b/supa-fighta/src/utils/lobbyUtils.js
@@ -1,9 +1,9 @@
 function broadcastToLobby(lobby, message) {
     const json = JSON.stringify(message);
     console.log(`Broadcasting to lobby: ${json}`);
-    lobby.players.forEach((ws) => {
-      if (ws.readyState === ws.OPEN) {
-        ws.send(json);
+    lobby.players.forEach((player) => {
+      if (player.ws.readyState === player.ws.OPEN) {
+        player.ws.send(json);
       }
     });
   }

--- a/supa-fighta/src/wsServer.js
+++ b/supa-fighta/src/wsServer.js
@@ -1,35 +1,32 @@
-// Initialize a server here for websockets 
 const WebSocket = require('ws');
 const crypto = require('crypto');
 const pool = require('./config/db');
 const { HandleMessage, HandleClose, MatchmakePlayers } = require('./controllers/lobbyController');
-const Player = require('./models/playerModel'); // Import the Player class
+const Player = require('./models/playerModel');
 
 const setupWebSocketServer = (port) => {
   const wss = new WebSocket.Server({ port: port });
 
   wss.on('connection', async (ws) => {
       ws.id = crypto.randomUUID();
-
-      // Create a Player instance
-      const player = new Player(ws, "player");
+      const player = new Player(ws);
 
       // Insert the player into the database
-      let result = await pool.query(`
+      pool.query(`
           INSERT INTO players (player_id, player_name, status)
           VALUES ($1, $2, 0)
           RETURNING *
       `, [player.id, player.username]);
 
-      // Pass the Player instance to the handlers
+      // Event Listners
       ws.on('message', message => HandleMessage(player, message));
       ws.on('close', () => HandleClose(player));
   });
 
   // Periodically run matchmaking
-  setInterval(() => {
-      MatchmakePlayers();
-  }, 5000); // Run matchmaking every 5 seconds
+  setInterval(async () => {
+      await MatchmakePlayers();
+  }, 5000);
   console.log('WebSocket server is listening on ws://localhost:8080');
 };
 


### PR DESCRIPTION
## Overview
The following bug was introduced in #2 where the server was not sending messages to the players in the lobby when a new player joined the lobby. This was happening due to a database query blocking the execution for the event listener on messages sent by the client.

## How it works
When a player joins the server they are added to the database for now. This is done async as we do not want to `await `the execution of the query blocking the execution of the `ws.on("message")` event listener.

## Next steps
* There was a new bug introduced in #3 as it is using the database to create matches