### PR TITLE
[Bug] Fixed matchmaking to use lobby object

### DIFF
--- a/supa-fighta/src/client.js
+++ b/supa-fighta/src/client.js
@@ -21,7 +21,9 @@ ws.on('message', (data) => {
     console.log(`👤 Player joined: ${msg.playerId}`);
   } else if (msg.type === 'player_left') {
     console.log(`👋 Player left: ${msg.playerId}`);
-  }  else if (msg.type === 'error') {
+  } else if(msg.type === "match_created"){
+    console.log(`🎮 We've got a game: ${msg.player1} vs ${msg.player2}`);
+  }else if (msg.type === 'error') {
     console.error(`❌ Error: ${msg.message}`);
   }
 });

--- a/supa-fighta/src/models/playerModel.js
+++ b/supa-fighta/src/models/playerModel.js
@@ -1,8 +1,12 @@
 class Player {
-    constructor(ws, username = 'Guest') {
+    constructor(ws, username = 'Guest', win_streak = 0, total_wins = 0, total_losses = 0) {
       this.id = ws.id;
       this.ws = ws;
       this.username = username;
+      this.status = 0
+      this.win_streak = win_streak
+      this.total_wins = total_wins
+      this.total_losses = total_losses
     }
   }
   


### PR DESCRIPTION
## Overview
The current matchmaking approach relied on making database queries to filter the optimal match configurations. This PR aims to remove that and utilize `LOBBY` object to filter players for match making

## How it works
This is a relatively simple fix the database queries have been removed and the players are sorted on the bases of their win_streak and later filtered based on their status to get the optimal matchup

## Next steps
* Once a player leaves the server their stats are updated in the database
* Proceed win writing game logic
