### PR TITLE
Add server - client communication for gamestate

### DIFF
--- a/supa-fighta-client/src/game/player.py
+++ b/supa-fighta-client/src/game/player.py
@@ -23,6 +23,7 @@ class Player:
             "parry": Animator(self.player_sprites["parry"], frame_rate=15, loop=False),
         }
         self.last_tap_time = {pygame.K_LEFT: 0, pygame.K_RIGHT: 0}
+        self._inputs = []
         self.player_x = x
         self.player_y = y
         self.speed = 2
@@ -53,7 +54,6 @@ class Player:
             else:
                 self.player_state = 'walk'
             self.velocity = -self.speed * ((DASH_FACTOR-0.5) if self.player_state == 'dash' else 1)
-            moved = True
             self.last_tap_time[pygame.K_LEFT] = now
         if keys[pygame.K_RIGHT]:
             delta_right_tap = now - self.last_tap_time[pygame.K_RIGHT]
@@ -63,13 +63,9 @@ class Player:
             else:
                 self.player_state = 'walk'
             self.velocity = self.speed * (DASH_FACTOR if self.player_state == 'dash' else 1)
-            moved = True
             self.last_tap_time[pygame.K_RIGHT] = now
+        self._inputs.append(self.player_state)
 
-        # if moved:
-        #     self.rect.move_ip(dx, dy)    # local prediction
-        #     # tell the server; keep the payload tiny
-        #     self.net.send("move", {"dx": dx, "dy": dy})
     def update(self):
         self.player_animations[self.player_state].update()
         self.player_x += self.velocity

--- a/supa-fighta-client/src/game/states/gameplayState.py
+++ b/supa-fighta-client/src/game/states/gameplayState.py
@@ -1,12 +1,16 @@
 from game.player import Player
-import pygame
+from server.ws_client import WSClient
 import config
+import pygame
+import time
 
 class GameplayState:
-    def __init__(self, net):
+    def __init__(self, net: WSClient):
         self.running = True
+        self.net = net
         self.player = Player(config.WINDOW_WIDTH // 2, config.WINDOW_HEIGHT // 2, net)
         self.background = pygame.image.load("./supa-fighta-client/assets/background.png").convert()
+        self._last_snapshot_time = time.time()
 
     def enter(self):
         self.running = True
@@ -14,9 +18,26 @@ class GameplayState:
         self.running = False
     def update(self):
         self.player.update()
+        now = time.time()
+        if now - self._last_snapshot_time >= 0.1:
+            snapshot = self._create_state_snapshot()
+            self.net.send_snapshot(snapshot)
+            self._last_snapshot_time = now
         
     def draw(self, screen: pygame.Surface):
         screen.blit(self.background, (0, 0))
         self.player.draw(screen)
+
+    def _create_state_snapshot(self):
+        snapshot = {
+            "timestamp": time.time(),
+            "player": {
+                "x": self.player.player_x,
+                "y": self.player.player_y,
+                "history": self.player._inputs,
+                "state": getattr(self.player, "player_state", "idel")
+            }
+        }
+        return snapshot
     def handle_event(self,event):
         pass

--- a/supa-fighta-client/src/main.py
+++ b/supa-fighta-client/src/main.py
@@ -1,5 +1,4 @@
 import pygame, sys, config
-from game.player import Player
 from server.ws_client import WSClient
 from game.stateManager import GameState
 

--- a/supa-fighta/src/config/db.js
+++ b/supa-fighta/src/config/db.js
@@ -5,4 +5,15 @@ const pool = new Pool({
    connectionString: config.pg_url
 });
 
+pool.connect()
+.then(client => {
+   console.log("✅ Database connected successfully");
+   client.release()
+})
+.catch(err => {
+   console.error("Database connection error:", err);
+   process.exit(1);
+})
+
+
 module.exports = pool;

--- a/supa-fighta/src/enums/index.js
+++ b/supa-fighta/src/enums/index.js
@@ -1,0 +1,2 @@
+const Inputs = require('./inputs');
+module.exports = { Inputs };

--- a/supa-fighta/src/enums/inputs.js
+++ b/supa-fighta/src/enums/inputs.js
@@ -1,0 +1,14 @@
+class Inputs {
+    static IDEL = 'idel';
+    static MOVE_LEFT = 'move_left';
+    static MOVE_RIGHT = 'move_right';
+    static ATTACK = 'attack';
+    static DASH = 'dash';
+    static PARRY = 'parry';
+
+    static isValid(input) {
+        return Object.values(Inputs).includes(input);
+        
+    }
+}
+module.exports = Inputs;

--- a/supa-fighta/src/models/playerState.js
+++ b/supa-fighta/src/models/playerState.js
@@ -1,8 +1,11 @@
+const { Inputs } = require("../enums");
+
 class PlayerState {
-    constructor(x = 0, y = 0) {
+    constructor(x = 320, y = 180) {
         this.x = x;
         this.y = y;
-        // You can add more properties here, e.g. velocity, health, etc.
+        this.vleocity = 0;
+        this.state = Inputs.IDEL
     }
 }
 

--- a/supa-fighta/src/wsServer.js
+++ b/supa-fighta/src/wsServer.js
@@ -21,12 +21,12 @@ const setupWebSocketServer = (port) => {
       }
 
       // Handle input messages for the game
-      if (data.type === 'input' && data.playerId && data.action) {
-        gameManager.routeInput(data.playerId, data.action);
-        return;
+      if ( data.type === "snapshot") {
+        // TODO: Validate and process the snapshot
+        console.log("Snapshot received:", data);
+        ws.send(JSON.stringify({ type: 'ack', message: 'valid state' }));
       }
 
-      // Otherwise, handle as a lobby message
       HandleMessage(ws, message);
     });
 


### PR DESCRIPTION
## Overview
Currently there was no server to client communication for the game. I've added changes that allow the client to create a snapshot of the game state and send it to the server. Also there are minor fixes for existing issues in this PR which couldn't be done in a separate PR

## How it works
The core idea is that whenever a game is tarted the inputs of the players are recorded and sent to the server while we keep updating the local game state for the client. The server then receives this input and responds with a validation response (not currently implemented). 

The game sate is sent to the server async so we don not have to wait for it to process and respond causing lag on client side we simply send the state and wait for the server respond in the background while the client is able to play the game normally. Currently the state is sent after 100ms but it is configurable.

## Next steps
* Add snapshot validation logic in the server.
* Add an opponent interface in the client to show opponent state to the client.